### PR TITLE
SecureLinkFactory::calculateLinkLifetime(): fix wrong check for page

### DIFF
--- a/Classes/Factory/SecureLinkFactory.php
+++ b/Classes/Factory/SecureLinkFactory.php
@@ -156,7 +156,7 @@ class SecureLinkFactory
     protected function calculateLinkLifetime(): int
     {
         // TODO: TSFE should always be available when dropping HTML parsing.
-        $cacheTimeout = ($GLOBALS['TSFE'] instanceof TypoScriptFrontendController && is_array($GLOBALS['TSFE']->page)) ? $GLOBALS['TSFE']->get_cache_timeout() : self::DEFAULT_CACHE_LIFETIME;
+        $cacheTimeout = ($GLOBALS['TSFE'] instanceof TypoScriptFrontendController && isset($GLOBALS['TSFE']->page['uid'])) ? $GLOBALS['TSFE']->get_cache_timeout() : self::DEFAULT_CACHE_LIFETIME;
 
         return $cacheTimeout + $GLOBALS['EXEC_TIME'] + $this->extensionConfiguration->getCacheTimeAdd();
     }


### PR DESCRIPTION
The condition to check if the current context is actually a page is broken, as reported in #74 . With TYPO3 9.5.x and logging (secure_downloads) enabled you will always get a: #1307190365 InvalidArgumentException (Unexpected value for parameter $tableDef. Expected <tablename>:<pid>, got 'tt_content:'.).