### PR TITLE
avoid http-header after file-transfer

### DIFF
--- a/Classes/Resource/FileDelivery.php
+++ b/Classes/Resource/FileDelivery.php
@@ -304,7 +304,7 @@ class FileDelivery
 
             $this->sendHeader($header);
             $this->outputFile($outputFunction, $file);
-            $this->exitScript('Okay', HttpUtility::HTTP_STATUS_200);
+            exit;
         }
 
         $this->exitScript('File does not exist!', HttpUtility::HTTP_STATUS_404);


### PR DESCRIPTION
Usage of HttpUtility was wrong here as the exit-methods there provide only functionality for exit() directly after header without content.