### PR TITLE
[BUGFIX] Set empty string if publicURL is not available

### DIFF
--- a/Classes/EventListener/SecureDownloadsEventListener.php
+++ b/Classes/EventListener/SecureDownloadsEventListener.php
@@ -54,7 +54,7 @@ class SecureDownloadsEventListener implements SingletonInterface
 
         if ($driver instanceof AbstractHierarchicalFilesystemDriver && ($resource instanceof File || $resource instanceof ProcessedFile)) {
             try {
-                $publicUrl = $driver->getPublicUrl($resource->getIdentifier());
+                $publicUrl = $driver->getPublicUrl($resource->getIdentifier()) ?? '';
                 if ($driver instanceof SecureDownloadsDriver || $this->secureDownloadService->pathShouldBeSecured($publicUrl)) {
                     $securedUrl = $this->getSecuredUrl($event->isRelativeToCurrentScript(), $publicUrl, $driver);
                     $event->setPublicUrl($securedUrl);


### PR DESCRIPTION
Related #91

With the non-public storages there is probably no publicUrl that must be intercepted. The coalescence operator is the simplest method, but maybe the code of "onIconFactoryEmitBuildIconForResourceSignal" makes more sense?

`$folder = $resource->getParentFolder();
$publicUrl = ($folder->getStorage()->getPublicUrl($folder) ?? $folder->getIdentifier()) . $resource->getName();`

Reproducible if you activate "Extended view" in the file list.