### PR TITLE
fix invalid call getRelativePathname on int

### DIFF
--- a/Classes/UserFunctions/CheckConfiguration.php
+++ b/Classes/UserFunctions/CheckConfiguration.php
@@ -106,16 +106,16 @@ class CheckConfiguration implements SingletonInterface
         foreach ($this->getPublicDirectories() as $publicDirectory) {
             $path = sprintf('%s/%s', Environment::getPublicPath(), $publicDirectory);
             $finder = (new Finder())->directories();
-            $directories = (array)$finder->in($path);
+            $directories = $finder->in($path);
             $this->getSuitableDirectories($directories, $publicDirectory);
         }
     }
 
     /**
-     * @param array  $directories
+     * @param Finder  $directories
      * @param string $publicDirectory
      */
-    protected function getSuitableDirectories(array $directories, string $publicDirectory)
+    protected function getSuitableDirectories(Finder $directories, string $publicDirectory)
     {
         foreach ($directories as $directory) {
             $directoryPath = sprintf('%s/%s', $publicDirectory, $directory->getRelativePathname());


### PR DESCRIPTION
This will fix an Error 'Call to a member function getRelativePathname() on int' when opening the ExtensionSettings in my Typo3 v10.4.16 installation.

Calling getRelativePathname (line 121) on a non-Finder-Instance will throw an Exception:
`Call to a member function getRelativePathname() on int`