### PR TITLE
FEATURE: Increase max logged filesize

### DIFF
--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -5,7 +5,7 @@ CREATE TABLE tx_securedownloads_domain_model_log (
 	file_id varchar(255) DEFAULT NULL,
 	file_name varchar(255) DEFAULT '' NOT NULL,
 	file_path varchar(255) DEFAULT '' NOT NULL,
-	file_size int(11) DEFAULT '0' NOT NULL,
+	file_size bigint(20) DEFAULT 0 NOT NULL,
 	file_type varchar(255) DEFAULT '' NOT NULL,
 	media_type varchar(255) DEFAULT '' NOT NULL,
 	protected varchar(255) DEFAULT '' NOT NULL,


### PR DESCRIPTION
This changes the file_size field to a bigint to accomodate logging file downloads of files with sizes larger than that of a 4-bit int