### PR TITLE
[TASK] Remove TCA configuration showRecordFieldList

### DIFF
--- a/Configuration/TCA/tx_securedownloads_domain_model_log.php
+++ b/Configuration/TCA/tx_securedownloads_domain_model_log.php
@@ -14,9 +14,6 @@ return [
         'searchFields' => '',
         'iconfile' => 'EXT:secure_downloads/Resources/Public/Icons/tx_securedownloads_domain_model_log.png',
     ],
-    'interface' => [
-        'showRecordFieldList' => '',
-    ],
     'types' => [
         '1' => ['showitem' => ''],
     ],


### PR DESCRIPTION
The TCA configuration `showRecordFieldList` inside the section `interface` is not evaluated anymore and all occurrences have been removed.

https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/10.3/Feature-88901-RenderAllFieldsInElementInformationController.html