### PR TITLE
Fix Error when using a non-Public Storage

### DIFF
--- a/Classes/EventListener/SecureDownloadsEventListener.php
+++ b/Classes/EventListener/SecureDownloadsEventListener.php
@@ -52,7 +52,7 @@ class SecureDownloadsEventListener implements SingletonInterface
         $driver = $event->getDriver();
         $resource = $event->getResource();
 
-        if ($driver instanceof AbstractHierarchicalFilesystemDriver && ($resource instanceof File || $resource instanceof ProcessedFile)) {
+        if ($driver instanceof AbstractHierarchicalFilesystemDriver && ($resource instanceof File || $resource instanceof ProcessedFile) && $resource->getStorage()->isPublic()) {
             try {
                 $publicUrl = $driver->getPublicUrl($resource->getIdentifier());
                 if ($driver instanceof SecureDownloadsDriver || $this->secureDownloadService->pathShouldBeSecured($publicUrl)) {


### PR DESCRIPTION
To reproduce the error create a new storage and disable the "is_publlic" toggle in the access tab.
After creating the storage (and filesystem folder) open the filelist, upload any file and refresh the view. The EventListener is trying to fetch the Public URL of the resource which is null in this case.

The Error-Message which is fixed in this PR:
```
Argument 1 passed to Leuchtfeuer\SecureDownloads\Service\SecureDownloadService::pathShouldBeSecured() must be of the type string, null given, called in typo3conf/ext/secure_downloads/Classes/EventListener/SecureDownloadsEventListener.php on line 59
```