### PR TITLE
Fixing exitScript function to keep exit messages appear again on the browser - Release-4.x -   /Classes/Resource/FileDelivery.php 

### DIFF
--- a/Classes/Resource/FileDelivery.php
+++ b/Classes/Resource/FileDelivery.php
@@ -214,7 +214,8 @@ class FileDelivery
     protected function exitScript(string $message, $httpStatus = HttpUtility::HTTP_STATUS_403): void
     {
         // TODO: Log message?
-        HttpUtility::setResponseCodeAndExit($httpStatus);
+        HttpUtility::setResponseCode($httpStatus);
+        exit($message);
     }
 
     /**


### PR DESCRIPTION
Fixing exitScript function to keep the exit messages appear again on the browser