### PR TITLE
[TASK] Small optimization in CheckConfiguration

### DIFF
--- a/Classes/UserFunctions/CheckConfiguration.php
+++ b/Classes/UserFunctions/CheckConfiguration.php
@@ -103,7 +103,8 @@ class CheckConfiguration implements SingletonInterface
      */
     protected function setDirectories(): void
     {
-        foreach ($this->getPublicDirectories() as $publicDirectory) {
+        $publicDirectories = $this->getPublicDirectories();
+        foreach ($publicDirectories as $publicDirectory) {
             $path = sprintf('%s/%s', Environment::getPublicPath(), $publicDirectory);
             $finder = (new Finder())->directories();
             $directories = $finder->in($path);


### PR DESCRIPTION
The function getPublicDirectories() scans the filesystem.
In order to execute this only once, the function is called
once and not in every iteration in the loop.