### PR TITLE
[TASK] Check for correct value in CheckConfiguration

### DIFF
--- a/Classes/UserFunctions/CheckConfiguration.php
+++ b/Classes/UserFunctions/CheckConfiguration.php
@@ -121,6 +121,9 @@ class CheckConfiguration implements SingletonInterface
             $directoryPath = sprintf('%s/%s', $publicDirectory, $directory->getRelativePathname());
             if (preg_match($this->directoryPattern, $directoryPath)) {
                 $realDirectoryPath = $directory->getRealPath();
+                if (!$realDirectoryPath) {
+                    continue;
+                }
                 $this->directories[] = $realDirectoryPath;
                 $this->checkFilesAccessibility($realDirectoryPath, $directoryPath);
             }


### PR DESCRIPTION
If something goes wrong when evaluating the path for a directory
(e.g. in the case of a dangling symbolic link) a value of false
is returned for the path. This would throw an exception if
proceeded with this value.

This patch checks if a value is returned before continuing and
prevents the exception.

Resolves: #130