### PR TITLE
[TASK] Optimization in CheckConfiguration (max 20)

### DIFF
--- a/Classes/UserFunctions/CheckConfiguration.php
+++ b/Classes/UserFunctions/CheckConfiguration.php
@@ -124,6 +124,9 @@ class CheckConfiguration implements SingletonInterface
                 $this->directories[] = $realDirectoryPath;
                 $this->checkFilesAccessibility($realDirectoryPath, $directoryPath);
             }
+            if ($this->fileCount >= 20) {
+                break;
+            }
         }
     }
 
@@ -133,22 +136,20 @@ class CheckConfiguration implements SingletonInterface
      */
     protected function checkFilesAccessibility(string $realDirectoryPath, string $directoryPath): void
     {
-        if ($this->fileCount < 20) {
-            $fileFinder = (new Finder())->name($this->fileTypePattern)->in($realDirectoryPath)->depth(0);
-            foreach ($fileFinder->files() as $file) {
-                $publicUrl = sprintf('%s/%s/%s', $this->domain, $directoryPath, $file->getRelativePathname());
-                $statusCode = (new Client())->request('HEAD', $publicUrl, ['http_errors' => false])->getStatusCode();
+        $fileFinder = (new Finder())->name($this->fileTypePattern)->in($realDirectoryPath)->depth(0);
+        foreach ($fileFinder->files() as $file) {
+            $publicUrl = sprintf('%s/%s/%s', $this->domain, $directoryPath, $file->getRelativePathname());
+            $statusCode = (new Client())->request('HEAD', $publicUrl, ['http_errors' => false])->getStatusCode();
 
-                if ($statusCode !== 403) {
-                    $this->fileCount++;
-                    $this->unprotectedFiles[] = [
-                        'url' => $publicUrl,
-                        'statusCode' => $statusCode,
-                    ];
+            if ($statusCode !== 403) {
+                $this->fileCount++;
+                $this->unprotectedFiles[] = [
+                    'url' => $publicUrl,
+                    'statusCode' => $statusCode,
+                ];
 
-                    if ($this->fileCount >= 20) {
-                        break;
-                    }
+                if ($this->fileCount >= 20) {
+                    break;
                 }
             }
         }


### PR DESCRIPTION
In CheckConfiguration (which is called when the Extension
Configuration dialog is opened), the filesystem is scanned
and a collection of files assembled which are not protected.
This only collects 20 files in any case, but the outer loop
continues - even if the 20 files limit is already reached.

This patch changes the behaviour, so that rendering is
started as soon as the 20 files limit is reached.

Related: #133