### PR TITLE
PHP 8.1 compatibility

### DIFF
--- a/Classes/Domain/Transfer/Token/AbstractToken.php
+++ b/Classes/Domain/Transfer/Token/AbstractToken.php
@@ -1,5 +1,6 @@
 <?php
-declare(strict_types = 1);
+declare(strict_types=1);
+
 namespace Leuchtfeuer\SecureDownloads\Domain\Transfer\Token;
 
 /***
@@ -12,7 +13,6 @@ namespace Leuchtfeuer\SecureDownloads\Domain\Transfer\Token;
  *  (c) 2020 Florian Wessels <f.wessels@Leuchtfeuer.com>, Leuchtfeuer Digital Marketing
  *
  ***/
-
 abstract class AbstractToken
 {
     /**
@@ -130,6 +130,6 @@ abstract class AbstractToken
 
     public function getHash(): string
     {
-        return md5($this->getUser() . $this->getGroups() . $this->getFile() . $this->getPage());
+        return md5($this->getUser() . implode('',$this->getGroups()) . $this->getFile() . $this->getPage());
     }
 }

--- a/Classes/Factory/SecureLinkFactory.php
+++ b/Classes/Factory/SecureLinkFactory.php
@@ -58,7 +58,7 @@ class SecureLinkFactory implements SingletonInterface
     protected function init()
     {
         $this->token->setExp($this->calculateLinkLifetime());
-        $this->token->setPage((int)$GLOBALS['TSFE']->id);
+        $this->token->setPage((int)($GLOBALS['TSFE']->id ?? 0));
 
         try {
             /** @var UserAspect $userAspect */
@@ -77,7 +77,7 @@ class SecureLinkFactory implements SingletonInterface
      */
     protected function calculateLinkLifetime(): int
     {
-        $cacheTimeout = ($GLOBALS['TSFE'] instanceof TypoScriptFrontendController && !empty($GLOBALS['TSFE']->page)) ? $GLOBALS['TSFE']->get_cache_timeout() : self::DEFAULT_CACHE_LIFETIME;
+        $cacheTimeout = (isset($GLOBALS['TSFE']) && $GLOBALS['TSFE'] instanceof TypoScriptFrontendController && !empty($GLOBALS['TSFE']->page)) ? $GLOBALS['TSFE']->get_cache_timeout() : self::DEFAULT_CACHE_LIFETIME;
 
         return $cacheTimeout + $GLOBALS['EXEC_TIME'] + $this->extensionConfiguration->getCacheTimeAdd();
     }

--- a/Classes/UserFunctions/CheckConfiguration.php
+++ b/Classes/UserFunctions/CheckConfiguration.php
@@ -124,6 +124,9 @@ class CheckConfiguration implements SingletonInterface
                 $this->directories[] = $realDirectoryPath;
                 $this->checkFilesAccessibility($realDirectoryPath, $directoryPath);
             }
+            if ($this->fileCount >= 20) {
+                break;
+            }
         }
     }
 
@@ -133,22 +136,20 @@ class CheckConfiguration implements SingletonInterface
      */
     protected function checkFilesAccessibility(string $realDirectoryPath, string $directoryPath): void
     {
-        if ($this->fileCount < 20) {
-            $fileFinder = (new Finder())->name($this->fileTypePattern)->in($realDirectoryPath)->depth(0);
-            foreach ($fileFinder->files() as $file) {
-                $publicUrl = sprintf('%s/%s/%s', $this->domain, $directoryPath, $file->getRelativePathname());
-                $statusCode = (new Client())->request('HEAD', $publicUrl, ['http_errors' => false])->getStatusCode();
+        $fileFinder = (new Finder())->name($this->fileTypePattern)->in($realDirectoryPath)->depth(0);
+        foreach ($fileFinder->files() as $file) {
+            $publicUrl = sprintf('%s/%s/%s', $this->domain, $directoryPath, $file->getRelativePathname());
+            $statusCode = (new Client())->request('HEAD', $publicUrl, ['http_errors' => false])->getStatusCode();
 
-                if ($statusCode !== 403) {
-                    $this->fileCount++;
-                    $this->unprotectedFiles[] = [
-                        'url' => $publicUrl,
-                        'statusCode' => $statusCode,
-                    ];
+            if ($statusCode !== 403) {
+                $this->fileCount++;
+                $this->unprotectedFiles[] = [
+                    'url' => $publicUrl,
+                    'statusCode' => $statusCode,
+                ];
 
-                    if ($this->fileCount >= 20) {
-                        break;
-                    }
+                if ($this->fileCount >= 20) {
+                    break;
                 }
             }
         }

--- a/Classes/UserFunctions/CheckConfiguration.php
+++ b/Classes/UserFunctions/CheckConfiguration.php
@@ -121,6 +121,9 @@ class CheckConfiguration implements SingletonInterface
             $directoryPath = sprintf('%s/%s', $publicDirectory, $directory->getRelativePathname());
             if (preg_match($this->directoryPattern, $directoryPath)) {
                 $realDirectoryPath = $directory->getRealPath();
+                if (!$realDirectoryPath) {
+                    continue;
+                }
                 $this->directories[] = $realDirectoryPath;
                 $this->checkFilesAccessibility($realDirectoryPath, $directoryPath);
             }

--- a/composer.json
+++ b/composer.json
@@ -24,10 +24,10 @@
     }
   ],
   "require": {
-    "typo3/cms-backend": "^10.4",
-    "typo3/cms-core": "^10.4",
-    "typo3/cms-extbase": "^10.4",
-    "typo3/cms-frontend": "^10.4",
+    "typo3/cms-backend": "^10.4 || ^11.5",
+    "typo3/cms-core": "^10.4 || ^11.5",
+    "typo3/cms-extbase": "^10.4 || ^11.5",
+    "typo3/cms-frontend": "^10.4 || ^11.5",
     "firebase/php-jwt": "^5.0",
     "ext-pdo": "*"
   },

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
     }
   ],
   "require": {
+    "php": "^7.2 || ^8.0",
     "typo3/cms-backend": "^10.4 || ^11.5",
     "typo3/cms-core": "^10.4 || ^11.5",
     "typo3/cms-extbase": "^10.4 || ^11.5",

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -14,7 +14,7 @@ $EM_CONF['secure_downloads'] = [
     'author_company' => 'Leuchtfeuer Digital Marketing',
     'constraints' => [
         'depends' => [
-            'php' => '7.2.0-8.0.99',
+            'php' => '7.2.0-8.1.99',
             'typo3' => '10.4.0-11.9.99',
         ],
         'conflicts' => [

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -14,8 +14,8 @@ $EM_CONF['secure_downloads'] = [
     'author_company' => 'Leuchtfeuer Digital Marketing',
     'constraints' => [
         'depends' => [
-            'php' => '7.2.0-7.4.99',
-            'typo3' => '10.4.0-10.4.99',
+            'php' => '7.2.0-8.0.99',
+            'typo3' => '10.4.0-11.9.99',
         ],
         'conflicts' => [
             'naw_securedl' => '',


### PR DESCRIPTION
This builds upon #128,#131,#132 for 11LTS compatibilty and adds PHP8.1 compatibility.

Basically the extension worked in PHP 8.1 in frontend, just in the backend e.g TSFE is not available and needs some graceful fallbacks.