### PR TITLE
[FEATURE] add option to skip checkConfiguration

### DIFF
--- a/Classes/Domain/Transfer/ExtensionConfiguration.php
+++ b/Classes/Domain/Transfer/ExtensionConfiguration.php
@@ -165,6 +165,15 @@ class ExtensionConfiguration implements SingletonInterface
     private $allowPublicAccess = true;
 
     /**
+     * If this option is activated, the checkConfiguration step in backend module extension configuration is skipped.
+     * This should be avoided, but comes in handy if there is a lot of folders as this could create long waits before the
+     * module is loaded.
+     *
+     * @var bool If true, checkConfiguration->render() is skipped
+     */
+    private $skipCheckConfiguration = false;
+
+    /**
      * @throws ExtensionConfigurationExtensionNotConfiguredException
      * @throws ExtensionConfigurationPathDoesNotExistException
      */
@@ -284,5 +293,10 @@ class ExtensionConfiguration implements SingletonInterface
     public function isAllowPublicAccess(): bool
     {
         return (bool)$this->allowPublicAccess;
+    }
+
+    public function isSkipCheckConfiguration(): bool
+    {
+        return (bool)$this->skipCheckConfiguration;
     }
 }

--- a/Classes/UserFunctions/CheckConfiguration.php
+++ b/Classes/UserFunctions/CheckConfiguration.php
@@ -80,6 +80,10 @@ class CheckConfiguration implements SingletonInterface
      */
     public function render(): string
     {
+        if ($this->extensionConfiguration->isSkipCheckConfiguration()) {
+            return '';
+        }
+
         $this->setDirectories();
 
         if (!empty($this->unprotectedFiles)) {

--- a/Resources/Private/Language/locallang_em.xlf
+++ b/Resources/Private/Language/locallang_em.xlf
@@ -58,6 +58,9 @@
             <trans-unit id="log">
                 <source>Log Module: Log each file access. This option will enable a backend module.</source>
             </trans-unit>
+            <trans-unit id="skipCheckConfiguration">
+                <source>Extension Configuration:  If this option is activated, the checkConfiguration step in backend module extension configuration is skipped. This should be avoided, but comes in handy if there is a lot of folders as this could create long waits before the module is loaded.</source>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -54,3 +54,6 @@ allowPublicAccess = 1
 
 # cat=Logging; type=boolean; label=LLL:EXT:secure_downloads/Resources/Private/Language/locallang_em.xlf:log
 log = 0
+
+# cat=Backend/010; type=boolean; label=LLL:EXT:secure_downloads/Resources/Private/Language/locallang_em.xlf:skipCheckConfiguration
+skipCheckConfiguration = 0


### PR DESCRIPTION
Every time one opens `Admin Tools > Settings > Extension Configuration` EXT:secure_downloads calls its `CheckConfiguration::render` to traverse all secured directories to check if they are configured properly.

However with about 15k secured files in about 200 folders this takes about 4mins in one of my faster systems making this module unusable. Thus, I propose to add an option to skip this.