### PR TITLE
[REGRESSION] backend.skipConfiguration doesn't skip new check

### DIFF
--- a/Classes/UserFunctions/CheckConfiguration.php
+++ b/Classes/UserFunctions/CheckConfiguration.php
@@ -88,7 +88,7 @@ class CheckConfiguration implements SingletonInterface
     public function renderCheckAccess(): string
     {
         if ($this->extensionConfiguration->isSkipCheckConfiguration()) {
-            return '';
+            return 'Check skipped as the option "backend.skipCheckConfiguration" is active';
         }
 
         $this->setDirectories();
@@ -114,6 +114,10 @@ class CheckConfiguration implements SingletonInterface
      */
     public function renderCheckDirs(): string
     {
+        if ($this->extensionConfiguration->isSkipCheckConfiguration()) {
+            return 'Check skipped as the option "backend.skipCheckConfiguration" is active';
+        }
+
         $this->setDirectories();
 
         if (count($this->protectedDirectories) === 0) {


### PR DESCRIPTION
A new check was introduced CheckConfiguration->renderCheckDirs() which isn't covered by the option to skip config checks in backend extension configuration.

Added a small exaplanatory label while at it.

rels: #139, #142