### PR TITLE
[BUGFIX] JWT::decode method signature not respected

### DIFF
--- a/Classes/Middleware/TokenRefreshMiddleware.php
+++ b/Classes/Middleware/TokenRefreshMiddleware.php
@@ -15,6 +15,7 @@ namespace Leuchtfeuer\SecureDownloads\Middleware;
  ***/
 
 use Firebase\JWT\JWT;
+use Firebase\JWT\Key;
 use Leuchtfeuer\SecureDownloads\Domain\Transfer\ExtensionConfiguration;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -86,7 +87,7 @@ class TokenRefreshMiddleware implements MiddlewareInterface
                 if (preg_match_all($pattern, $content, $foundJwtTokens)) {
                     foreach ($foundJwtTokens[1] as $foundJwtToken) {
                         try {
-                            $data = JWT::decode($foundJwtToken, $GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey'], ['HS256']);
+                            $data = JWT::decode($foundJwtToken, new Key($GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey'], 'HS256'));
                             if ((int)$data->user !== $currentUserId) {
                                 $data->user = $currentUserId;
                                 $newToken = JWT::encode($data, $GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey'], 'HS256');

--- a/Classes/Middleware/TokenRefreshMiddleware.php
+++ b/Classes/Middleware/TokenRefreshMiddleware.php
@@ -90,7 +90,7 @@ class TokenRefreshMiddleware implements MiddlewareInterface
                             $data = JWT::decode($foundJwtToken, new Key($GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey'], 'HS256'));
                             if ((int)$data->user !== $currentUserId) {
                                 $data->user = $currentUserId;
-                                $newToken = JWT::encode($data, $GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey'], 'HS256');
+                                $newToken = JWT::encode((array)$data, $GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey'], 'HS256');
                                 $replaces[$foundJwtToken] = $newToken;
                             }
                         } catch (\Exception $exception) {


### PR DESCRIPTION
A list of downloads behind a login worked like a charm. Suddenly I get a 503 `/private/typo3conf/ext/secure_downloads/Classes/Middleware/TokenRefreshMiddleware.php, line 89: Cannot pass parameter 3 by reference`. The links are generated fine, as long as the user is not logged in. As soon as an fe user session is there (even if the tt_content itself has no access restrictions) the 503 occurs.

From the source it just seems like an wrong method signature, probably introduced by the upgrade from JWT 5 to 6 in 146b7e72a67e43dacdf5bc0329f5a76fefc02d56
Thus, I propose to fix this in accordance to the JWT 6 example. This resolves the 503.
