### PR TITLE
[BUGFIX] Fix list module if icons from files in secured directories a…

### DIFF
--- a/Classes/EventListener/SecureDownloadsEventListener.php
+++ b/Classes/EventListener/SecureDownloadsEventListener.php
@@ -21,6 +21,7 @@ use TYPO3\CMS\Core\Imaging\Event\ModifyIconForResourcePropertiesEvent;
 use TYPO3\CMS\Core\Resource\Driver\AbstractHierarchicalFilesystemDriver;
 use TYPO3\CMS\Core\Resource\Event\GeneratePublicUrlForResourceEvent;
 use TYPO3\CMS\Core\Resource\Exception;
+use TYPO3\CMS\Core\Resource\Exception\InsufficientFolderAccessPermissionsException;
 use TYPO3\CMS\Core\Resource\File;
 use TYPO3\CMS\Core\Resource\Folder;
 use TYPO3\CMS\Core\Resource\ProcessedFile;
@@ -90,10 +91,14 @@ class SecureDownloadsEventListener implements SingletonInterface
                     $overlayIdentifier = 'overlay-restricted';
                 }
             } elseif ($resource instanceof File) {
-                $folder = $resource->getParentFolder();
-                $publicUrl = ($folder->getStorage()->getPublicUrl($folder) ?? $folder->getIdentifier()) . $resource->getName();
-                if ($this->secureDownloadService->pathShouldBeSecured($publicUrl)) {
-                    $overlayIdentifier = 'overlay-restricted';
+                try {
+                    $folder = $resource->getParentFolder();
+                    $publicUrl = ($folder->getStorage()->getPublicUrl($folder) ?? $folder->getIdentifier()) . $resource->getName();
+                    if ($this->secureDownloadService->pathShouldBeSecured($publicUrl)) {
+                        $overlayIdentifier = 'overlay-restricted';
+                    }
+                } catch (InsufficientFolderAccessPermissionsException $e) {
+                    return;
                 }
             }
         }


### PR DESCRIPTION
…re displayed and the editor has no access to the parent folder [TER-139] [TER-140]

[TER-139]: https://leuchtfeuer-com.atlassian.net/browse/TER-139?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TER-140]: https://leuchtfeuer-com.atlassian.net/browse/TER-140?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ