### PR TITLE
[BUGFIX] Check for CLI usage

### DIFF
--- a/Classes/Factory/SecureLinkFactory.php
+++ b/Classes/Factory/SecureLinkFactory.php
@@ -67,12 +67,15 @@ class SecureLinkFactory implements SingletonInterface
     {
         $this->token->setExp($this->calculateLinkLifetime());
         $request = $this->getRequest();
-        if (ApplicationType::fromRequest($request)->isFrontend()) {
-            $pageArguments = $request->getAttribute('routing');
-            $pageId = $pageArguments->getPageId();
-        } elseif (ApplicationType::fromRequest($request)->isBackend()) {
-            $site = $request->getAttribute('site');
-            $pageId = $site->getRootPageId();
+        if (!Environment::isCli()) {
+            $request = $this->getRequest();
+            if (ApplicationType::fromRequest($request)->isFrontend()) {
+                $pageArguments = $request->getAttribute('routing');
+                $pageId = $pageArguments->getPageId();
+            } elseif (ApplicationType::fromRequest($request)->isBackend()) {
+                $site = $request->getAttribute('site');
+                $pageId = $site->getRootPageId();
+            }
         }
         $this->token->setPage($pageId ?? 0);
 


### PR DESCRIPTION
If using solrfal and indexing via scheduler call, the `$GLOBALS['TYPO3_REQUEST`]` is empty which leads to exception

```
Leuchtfeuer\SecureDownloads\Factory\SecureLinkFactory::getRequest(): Return value must be of type TYPO3\CMS\Core\Http\ServerRequest, null returned
```