### PR TITLE
[BUGFIX] Allow custom filename from Event

### DIFF
--- a/Classes/Resource/FileDelivery.php
+++ b/Classes/Resource/FileDelivery.php
@@ -90,7 +90,8 @@ class FileDelivery implements SingletonInterface
                     ->getStorage()
                     ->streamFile(
                         $fileObject,
-                        $this->shouldForceDownload($fileObject->getExtension())
+                        $this->shouldForceDownload($fileObject->getExtension()),
+                        $fileName
                     );
                 ob_end_clean();
 


### PR DESCRIPTION
When setting a custom file name via the Event,
the change is not set to the ResourceStorage.

This change adds the custom file name to the streamFile method.