### PR TITLE
support null value for page arguments

### DIFF
--- a/Classes/Factory/SecureLinkFactory.php
+++ b/Classes/Factory/SecureLinkFactory.php
@@ -70,7 +70,7 @@ class SecureLinkFactory implements SingletonInterface
             $request = $this->getRequest();
             if (ApplicationType::fromRequest($request)->isFrontend()) {
                 $pageArguments = $request->getAttribute('routing');
-                $pageId = $pageArguments->getPageId();
+                $pageId = $pageArguments?->getPageId();
             } elseif (ApplicationType::fromRequest($request)->isBackend()) {
                 $site = $request->getAttribute('site');
                 $pageId = $site->getRootPageId();


### PR DESCRIPTION
For some uses, there is no routing value in the request and the creation of the link throws an error.

Error Message was:

`Core: Exception handler (WEB): Uncaught TYPO3 Exception: Call to a member function getPageId() on null | Error thrown in file /var/www/html/vendor/leuchtfeuer/secure-downloads/Classes/Factory/SecureLinkFactory.php in line 74`
