### PR TITLE
[BUGFIX] prevent undefined array access

### DIFF
--- a/Classes/Factory/SecureLinkFactory.php
+++ b/Classes/Factory/SecureLinkFactory.php
@@ -80,7 +80,7 @@ class SecureLinkFactory implements SingletonInterface
 
     private function getRequest(): ?ServerRequestInterface
     {
-        return $GLOBALS['TYPO3_REQUEST'];
+        return $GLOBALS['TYPO3_REQUEST'] ?? null;
     }
 
     /**


### PR DESCRIPTION
a PHP Warning is triggerd when calling getPublicUrl of a file without TYPO3_REQUEST, e.g. when calling method from cli