### PR TITLE
[BUGFIX] Handle missing request object in SecureLinkFactory

### DIFF
--- a/Classes/Factory/SecureLinkFactory.php
+++ b/Classes/Factory/SecureLinkFactory.php
@@ -80,7 +80,7 @@ class SecureLinkFactory implements SingletonInterface
 
     private function getRequest(): ?ServerRequestInterface
     {
-        return $GLOBALS['TYPO3_REQUEST'];
+        return $GLOBALS['TYPO3_REQUEST'] ?? null;
     }
 
     /**


### PR DESCRIPTION
For example, if SecureLinkFactory is accessed in an eID request, the request object has not yet been created.

I have manually tested this patch in my TYPO3 v12 with leuchtfeuer/secure-downloads:6.1.1. It can probably be integrated into the main branch, but I tested it with the release-6.x branch.

Fixes: #235 