### PR TITLE
[DOCS] Remove accidental citations on the start page

### DIFF
--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -38,25 +38,25 @@ Secure Downloads
 
 **TYPO3**
 
-   The content of this document is related to TYPO3, a GNU/GPL CMS/Framework available from `www.typo3.org <http://www.typo3.org/>`_.
+The content of this document is related to TYPO3, a GNU/GPL CMS/Framework available from `www.typo3.org <http://www.typo3.org/>`_.
 
 **Community documentation:**
 
-   This document is *not* official TYPO3 documentation.
+This document is *not* official TYPO3 documentation.
 
-   It is maintained as part of a third party extension.
+It is maintained as part of a third party extension.
 
-   If you find an error or something is missing, please:
-   `Report a problem <https://github.com/Leuchtfeuer/typo3-secure-downloads/issues/new>`__
+If you find an error or something is missing, please:
+`Report a problem <https://github.com/Leuchtfeuer/typo3-secure-downloads/issues/new>`__
 
 **Extension Manual**
 
-   This documentation is for the TYPO3 extension secure_downloads.
+This documentation is for the TYPO3 extension secure_downloads.
 
 **For Contributors**
 
-   You are welcome to help improve this guide. Just click on "Edit me on GitHub" on the top right to submit your
-   change request.
+You are welcome to help improve this guide. Just click on "Edit me on GitHub" on the top right to submit your
+change request.
 
 :ref:`sitemap`
 


### PR DESCRIPTION
Indenting blocks of text marks them as citation, which creates an unruly appearance on the start page of your manual. Removed them.