### PR TITLE
[DOCS] Fix incorrect URL encoding function in example [TER-330]

### DIFF
--- a/Documentation/Developer/SecuredLinks/Index.rst
+++ b/Documentation/Developer/SecuredLinks/Index.rst
@@ -54,7 +54,7 @@ Get a link that is only valid for user `29`, with user group `12`, is generated 
 
    if ($secureDownloadService->pathShouldBeSecured($publicUrl)) {
        $securedUrl = GeneralUtility::makeInstance(SecureLinkFactory::class)
-           ->withResourceUri(rawurlencode($publicUrl))
+           ->withResourceUri(rawurldecode($publicUrl))
            ->withUser(29)
            ->withPage(89)
            ->withGroups([12])


### PR DESCRIPTION
Changed rawurlencode to rawurldecode in the SecureLinkFactory example to correctly demonstrate the proper usage of the withResourceUri method.