### PR TITLE
[DOCS] Add version 5.0.7 to changelog index

### DIFF
--- a/Documentation/About/ChangeLog/Index.rst
+++ b/Documentation/About/ChangeLog/Index.rst
@@ -17,6 +17,7 @@ List of versions
     :titlesonly:
     :glob:
 
+    5-0-7
     5-0-6
     5-0-5
     5-0-4


### PR DESCRIPTION
This change adds the 5.0.7 changelog entry to the documentation index, making it accessible in the rendered documentation.